### PR TITLE
Run LO in the same process

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.2
+current_version = 0.3.3
 commit = True
 tag = True
 tag_name = {new_version}

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     'pylokit==0.8.1',
-    'django>=1.8,<=1.11',
+    'django>=1.8,<1.12',
 ]
 
 test_requirements = [
@@ -22,7 +22,7 @@ test_requirements = [
 
 setup(
     name='templateddocs',
-    version='0.3.2',
+    version='0.3.3',
     description=('Generate PDF, MS Word and Excel documents from templates '
                  'in Django.'),
     long_description=readme + '\n\n' + history,

--- a/templated_docs/__init__.py
+++ b/templated_docs/__init__.py
@@ -80,9 +80,9 @@ def find_template_file(template_name):
 def _convert_file(filename, format, result_queue=None, options=None):
     """Helper function to convert a file via LOKit.
 
-    This function can be called via subprocess so that in the event of LO crashing randomly
-    after conversion, it will not terminate the parent process. This is assisted by inserting
-    the result into a Queue object.
+    This function can be called via subprocess so that in the event of LO
+    crashing randomly after conversion, it will not terminate the parent
+    process. This is assisted by inserting the result into a Queue object.
     """
     lo_path = getattr(
         settings,
@@ -96,14 +96,21 @@ def _convert_file(filename, format, result_queue=None, options=None):
             doc.saveAs(str(conv_file.name), options=options)
         os.unlink(filename)
 
-    # type comparison is required instead of isinstance owing to multiprocessing.Queue is a method
+    # type comparison is required instead of isinstance owing to
+    # multiprocessing.Queue is a method
     if type(result_queue) == multiprocessing.queues.Queue:
         result_queue.put(conv_file.name)
     else:
         return conv_file.name
 
 
-def fill_template(template_name, context, output_format='odt', options=None, separate_process=True):
+def fill_template(
+    template_name,
+    context,
+    output_format='odt',
+    options=None,
+    separate_process=True,
+):
     """Fill a document with data and convert it to the requested format.
 
     Returns an absolute path to the generated file.
@@ -111,10 +118,12 @@ def fill_template(template_name, context, output_format='odt', options=None, sep
     Supported output format:
         Text documents: doc, docx, fodt, html, odt, ott, pdf, txt, xhtml, png
         Spreadsheets: csv, fods, html, ods, ots, pdf, xhtml, xls, xlsx, png
-        Presentations: fodp, html, odg, odp, otp, pdf, potm, pot, pptx, pps, ppt, svg, swf, xhtml, png
+        Presentations: fodp, html, odg, odp, otp, pdf, potm, pot, pptx, pps,
+                       ppt, svg, swf, xhtml, png
         Drawings: fodg, html, odg, pdf, svg, swf, xhtml, png
 
-    More on filter options, https://wiki.openoffice.org/wiki/Documentation/DevGuide/Spreadsheets/Filter_Options
+    More on filter options,
+    https://wiki.openoffice.org/wiki/Documentation/DevGuide/Spreadsheets/Filter_Options  # noqa: E501
 
     :param template_name: the path to template, in OpenDocument format
     :param context: the context to be used to inject content
@@ -171,8 +180,10 @@ def fill_template(template_name, context, output_format='odt', options=None, sep
     if source_extension[1:] != output_format:
         if separate_process:
             results = multiprocessing.Queue()
-            converter = multiprocessing.Process(target=_convert_file,
-                                args=(str(dest_file.name), output_format, results, options))
+            converter = multiprocessing.Process(
+                target=_convert_file,
+                args=(str(dest_file.name), output_format, results, options),
+            )
             converter.start()
             return results.get()
         else:

--- a/templated_docs/__init__.py
+++ b/templated_docs/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from multiprocessing import Process, Queue
+import multiprocessing
 import os.path
 import re
 from tempfile import NamedTemporaryFile
@@ -96,7 +96,8 @@ def _convert_file(filename, format, result_queue=None, options=None):
             doc.saveAs(str(conv_file.name), options=options)
         os.unlink(filename)
 
-    if isinstance(result_queue, Queue):
+    # type comparison is required instead of isinstance owing to multiprocessing.Queue is a method
+    if type(result_queue) == multiprocessing.queues.Queue:
         result_queue.put(conv_file.name)
     else:
         return conv_file.name
@@ -169,8 +170,8 @@ def fill_template(template_name, context, output_format='odt', options=None, sep
 
     if source_extension[1:] != output_format:
         if separate_process:
-            results = Queue()
-            converter = Process(target=_convert_file,
+            results = multiprocessing.Queue()
+            converter = multiprocessing.Process(target=_convert_file,
                                 args=(str(dest_file.name), output_format, results, options))
             converter.start()
             return results.get()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34}-django{18,19,110}, flake8
+envlist = py{27,34}-django{18,19,110,111}, flake8
 
 [testenv:flake8]
 deps=flake8
@@ -12,5 +12,6 @@ deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<1.12
 commands = python tests/manage.py test
     python example/manage.py check


### PR DESCRIPTION
Problem:
Current code will not run in celery due to
`AssertionError: daemonic processes are not allowed to have children`

Solution:
This isn't a proper solution, just wanted a snippet we can use to discuss.
See these to understand context on why `Process` was used:
- https://github.com/alexmorozov/templated-docs/issues/3
- https://github.com/alexmorozov/templated-docs/commit/b0a66692b251f2a9198c5073a66b8888f6c6d57a

`Process` was used to prevent django from crashing on LO errors. I made it run in the same process.

`Thread` here is not needed, just wanted to change least amount of code to get it running on our beta server.

---

Along with this PR, version is bumped to `0.3.3` and support for Django `1.11.x` is added.